### PR TITLE
Build git action for PR and release

### DIFF
--- a/.github/workflows/build-release-master.yml
+++ b/.github/workflows/build-release-master.yml
@@ -1,0 +1,43 @@
+name: Build and Release Master
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build for ${{ matrix.Java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: |
+          export JAVA_COMPILATION_VERSION=11
+          ./gradlew build
+          export JAVA_COMPILATION_VERSION=8
+          ./gradlew build
+      - name: Bump Release Version
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v5.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          name: ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+          draft: true
+          prerelease: false
+          files: ./streaming-connect-sink/build/libs/streaming-connect-sink-*.jar

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -1,0 +1,24 @@
+name: Pull Request Build and Test
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+    name: Build for ${{ matrix.Java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew clean build


### PR DESCRIPTION
## Summary
Build git action for PR and release. Currently release is in draft mode, after release cut one have to manually see if all looks ok and publish it. Release could later be modified to directly publish without manual intervention. 

## Changes
- Build git action for PR and release
