### PR TITLE
#25 Fix JWT token expiry

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 ##
 
 group=com.adobe.platform.streaming
-versionMain=0.0.5
+versionMain=0.0.6
 versionQualifier=
 
 param_artifactory_user=

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/auth/impl/JWTTokenProvider.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/auth/impl/JWTTokenProvider.java
@@ -154,7 +154,7 @@ public class JWTTokenProvider extends AbstractAuthProvider {
       );
       JSONObject tokenBodyJson = new JSONObject(tokenBody);
       long expiresIn = ((Number)tokenBodyJson.get(JWT_EXPIRY_KEY)).longValue();
-      return System.currentTimeMillis() <= (expiresIn - DEFAULT_JWT_TOKEN_UPDATE_THRESHOLD);
+      return System.currentTimeMillis() > (expiresIn - DEFAULT_JWT_TOKEN_UPDATE_THRESHOLD);
     } catch (UnsupportedEncodingException exception) {
       LOG.error("Exception while parsing JWT token", exception);
     }


### PR DESCRIPTION
## Summary
Fix JWT token expiry : Token once expired is never refresh due to comparison operator bug

## Related Issue

https://github.com/adobe/experience-platform-streaming-connect/issues/25
Internal Id - PLATIR-14853 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Changes

- Fix JWT token expiry : Token once expired is never refresh due to comparison operator bug

## Relevant Documentation

_Please enter the links of any docs updated to reflect this change_

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [*] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
