### PR TITLE
Added support for http proxy

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -34,6 +34,10 @@ AEP Sink connector configurations can be supplied in the call register the conne
 | key.converter.schemas.enable      | enables conversion of schemas                   | false                                                   | no       |                         |
 | value.converter.schemas.enable    | enables conversion of schemas                   | false                                                   | no       |                         |
 | aep.endpoint                      | aep streaming endpoint url                      |                                                         | yes      |                         |
+| aep.connection.proxy.host         | address of the proxy host to connect through    |                                                         | no       |                         |
+| aep.connection.proxy.port         | port of the proxy host to connect through       |                                                         | no       |                         |
+| aep.connection.proxy.user         | username for the proxy host                     |                                                         | no       |                         |
+| aep.connection.proxy.password     | password for the proxy host                     |                                                         | no       |                         |
 | aep.connection.auth.enabled       | required for authenticated streaming endpoint   | false                                                   | no       |                         |
 | aep.connection.auth.token.type    | always set to access_token                      | access_token                                            | no       |                         |
 | aep.connection.auth.client.id     | IMS client id                                   |                                                         | no       |                         |

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
@@ -79,12 +79,12 @@ public class HttpConnection {
 
     while (retries++ < maxRetries) {
       try {
-        URL request = new URL(new URL(endpoint), url);
+        final URL request = new URL(new URL(endpoint), url);
         LOG.debug("opening connection for: {}", request);
 
         if (isBasicProxyConfigured()) {
           if (isProxyWithAuthenticationConfigured()) {
-            LOG.debug("proxyUser: {}, proxyPassword: {}", proxyHost, proxyPassword);
+            LOG.debug("proxyUser: {}, proxyPassword: {}", proxyUser, proxyPassword);
             Authenticator.setDefault(
               new Authenticator() {
                 @Override
@@ -96,7 +96,7 @@ public class HttpConnection {
           }
 
           LOG.debug("proxyHost: {}, proxyPort: {}", proxyHost, proxyPort);
-          Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
+          final Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
           conn = (HttpURLConnection) request.openConnection(proxy);
         } else {
           conn = (HttpURLConnection) request.openConnection();

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
@@ -84,8 +84,9 @@ public class HttpConnection {
 
         if (isBasicProxyConfigured()) {
           if (isProxyWithAuthenticationConfigured()) {
+            LOG.debug("proxyUser: {}, proxyPassword: {}", proxyHost, proxyPassword);
             Authenticator.setDefault(
-                new Authenticator() {
+              new Authenticator() {
                 @Override
                 protected PasswordAuthentication getPasswordAuthentication() {
                   return new PasswordAuthentication(proxyUser, proxyPassword.toCharArray());
@@ -94,6 +95,7 @@ public class HttpConnection {
             );
           }
 
+          LOG.debug("proxyHost: {}, proxyPort: {}", proxyHost, proxyPort);
           Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
           conn = (HttpURLConnection) request.openConnection(proxy);
         } else {
@@ -205,14 +207,14 @@ public class HttpConnection {
   }
 
   public boolean isBasicProxyConfigured() {
-    return (proxyHost != null && !proxyHost.isEmpty())
-            && (proxyPort != null && !proxyPort.isEmpty());
+    return (proxyHost != null && !proxyHost.isEmpty()) &&
+        (proxyPort != null && !proxyPort.isEmpty());
   }
 
   public boolean isProxyWithAuthenticationConfigured() {
-    return isBasicProxyConfigured()
-            && (proxyUser != null && !proxyUser.isEmpty())
-            && (proxyPassword != null && !proxyPassword.isEmpty());
+    return isBasicProxyConfigured() &&
+        (proxyUser != null && !proxyUser.isEmpty()) &&
+        (proxyPassword != null && !proxyPassword.isEmpty());
   }
 
   public InputStream getInputStream() throws HttpException {

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
@@ -82,7 +82,7 @@ public class HttpProducer implements Serializable {
     return new HttpConnection.HttpConnectionBuilder()
       .withEndpoint(endpoint)
       .withProxyHost(proxyHost)
-      .withProxyPort(proxyHost)
+      .withProxyPort(proxyPort)
       .withProxyUser(proxyUser)
       .withProxyPassword(proxyPassword)
       .withConnectTimeout(connectTimeout)

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
@@ -30,6 +30,12 @@ public class HttpProducer implements Serializable {
   private static final String CONTENT_TYPE = "Content-type";
 
   private final String endpoint;
+
+  private String proxyHost;
+  private String proxyPort;
+  private String proxyUser;
+  private String proxyPassword;
+
   private final boolean enableGzip;
   private int connectTimeout;
   private transient AuthProvider auth;
@@ -75,6 +81,10 @@ public class HttpProducer implements Serializable {
   private HttpConnection.HttpConnectionBuilder newConnectionBuilder() {
     return new HttpConnection.HttpConnectionBuilder()
       .withEndpoint(endpoint)
+      .withProxyHost(proxyHost)
+      .withProxyPort(proxyHost)
+      .withProxyUser(proxyUser)
+      .withProxyPassword(proxyPassword)
       .withConnectTimeout(connectTimeout)
       .withAuth(auth)
       .withReadTimeout(readTimeout)
@@ -94,6 +104,26 @@ public class HttpProducer implements Serializable {
 
     HttpProducerBuilder(HttpProducer instance) {
       this.instance = instance;
+    }
+
+    public HttpProducerBuilder withProxyHost(String proxyHost) {
+      instance.proxyHost = proxyHost;
+      return this;
+    }
+
+    public HttpProducerBuilder withProxyPort(String proxyPort) {
+      instance.proxyPort = proxyPort;
+      return this;
+    }
+
+    public HttpProducerBuilder withProxyUser(String proxyUser) {
+      instance.proxyUser = proxyUser;
+      return this;
+    }
+
+    public HttpProducerBuilder withProxyPassword(String proxyPassword) {
+      instance.proxyPassword = proxyPassword;
+      return this;
     }
 
     public HttpProducerBuilder withReadTimeout(int readTimeout) {

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractAEPPublisher.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractAEPPublisher.java
@@ -38,6 +38,12 @@ public abstract class AbstractAEPPublisher implements DataPublisher {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractAEPPublisher.class);
 
   private static final String AEP_ENDPOINT = "aep.endpoint";
+
+  private static final String AEP_CONNECTION_PROXY_HOST = "aep.connection.proxy.host";
+  private static final String AEP_CONNECTION_PROXY_PORT = "aep.connection.proxy.port";
+  private static final String AEP_CONNECTION_PROXY_USER = "aep.connection.proxy.user";
+  private static final String AEP_CONNECTION_PROXY_PASSWORD = "aep.connection.proxy.password";
+
   private static final String AEP_CONNECTION_TIMEOUT = "aep.connection.timeout";
   private static final String AEP_CONNECTION_MAX_RETRIES = "aep.connection.maxRetries";
   private static final String AEP_CONNECTION_MAX_RETRIES_BACKOFF = "aep.connection.retryBackoff";
@@ -62,6 +68,10 @@ public abstract class AbstractAEPPublisher implements DataPublisher {
 
   protected HttpProducer getHttpProducer(Map<String, String> props) throws AEPStreamingException {
     return HttpProducer.newBuilder(getAepEndpoint(props.get(AEP_ENDPOINT)))
+      .withProxyHost(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_HOST, null))
+      .withProxyPort(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_PORT, null))
+      .withProxyUser(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_USER, null))
+      .withProxyPassword(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_PASSWORD, null))
       .withConnectTimeout(SinkUtils.getProperty(props, AEP_CONNECTION_TIMEOUT, 5000))
       .withReadTimeout(SinkUtils.getProperty(props, AEP_CONNECTION_READ_TIMEOUT, 60000))
       .withMaxRetries(SinkUtils.getProperty(props, AEP_CONNECTION_MAX_RETRIES, 3))

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -124,7 +124,8 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
     String connectorProperties = String.format(HttpUtil.streamToString(this.getClass().getClassLoader()
       .getResourceAsStream(AEP_CONNECTOR_CONFIG_WITH_PROXY)),
       NUMBER_OF_TASKS,
-      getInletUrl());
+      getInletUrl(),
+      PORT_VIA_PROXY);
 
     Map<String, String> connectorConfig = MAPPER.readValue(connectorProperties,
       new TypeReference<Map<String, String>>() {});

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -124,7 +124,7 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
     String connectorProperties = String.format(HttpUtil.streamToString(this.getClass().getClassLoader()
       .getResourceAsStream(AEP_CONNECTOR_CONFIG_WITH_PROXY)),
       NUMBER_OF_TASKS,
-      getInletUrlViaProxy());
+      getInletUrl());
 
     Map<String, String> connectorConfig = MAPPER.readValue(connectorProperties,
       new TypeReference<Map<String, String>>() {});

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
@@ -145,10 +145,6 @@ public abstract class AbstractConnectorTest {
     return baseUrl.concat(relativePath);
   }
 
-  protected String getInletUrlViaProxy() {
-    return baseUrlViaProxy.concat(relativePath);
-  }
-
   public int getNumberOfWorkers() {
     return numberOfWorkers;
   }

--- a/streaming-connect-sink/src/test/resources/aep-connector-with-proxy.json
+++ b/streaming-connect-sink/src/test/resources/aep-connector-with-proxy.json
@@ -8,5 +8,5 @@
   "value.converter.schemas.enable": "false",
   "aep.endpoint": "%s",
   "aep.connection.proxy.host": "localhost",
-  "aep.connection.proxy.port": "8090"
+  "aep.connection.proxy.port": "%s"
 }

--- a/streaming-connect-sink/src/test/resources/aep-connector-with-proxy.json
+++ b/streaming-connect-sink/src/test/resources/aep-connector-with-proxy.json
@@ -1,0 +1,12 @@
+{
+  "topics": "connect-test",
+  "tasks.max": "%s",
+  "aep.flush.interval.seconds": "1",
+  "aep.flush.bytes.kb": "4",
+  "connector.class": "com.adobe.platform.streaming.sink.impl.AEPSinkConnector",
+  "key.converter.schemas.enable": "false",
+  "value.converter.schemas.enable": "false",
+  "aep.endpoint": "%s",
+  "aep.connection.proxy.host": "localhost",
+  "aep.connection.proxy.port": "8090"
+}


### PR DESCRIPTION
## Summary
Added support for http proxy to the connector configuration. This allows the user to add proxy host details when using the connector within a corporate environment having proxy host.

## Related Issue

https://github.com/adobe/experience-platform-streaming-connect/issues/26

## Changes

Added support for http proxy with the following connector configuration
- aep.connection.proxy.host: address of the proxy host to connect through 
- aep.connection.proxy.port: port of the proxy host to connect through
- aep.connection.proxy.user: username for the proxy host
- aep.connection.proxy.password: password for the proxy host 

## Relevant Documentation
DEVELOPER_GUIDE.md

## How Has This Been Tested?
Added a new test case `aepSinkConnectorTestViaProxy()` to the existing test suite. To execute this test case, have setup a new mock extention `wiremockExtensionViaProxy` which acts as a proxy server to redirect the request to the actual `wiremockExtension`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
