### PR TITLE
Added support for http proxy

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -34,6 +34,10 @@ AEP Sink connector configurations can be supplied in the call register the conne
 | key.converter.schemas.enable      | enables conversion of schemas                   | false                                                   | no       |                         |
 | value.converter.schemas.enable    | enables conversion of schemas                   | false                                                   | no       |                         |
 | aep.endpoint                      | aep streaming endpoint url                      |                                                         | yes      |                         |
+| aep.connection.proxy.host         | address of the proxy host to connect through    |                                                         | no       |                         |
+| aep.connection.proxy.port         | port of the proxy host to connect through       |                                                         | no       |                         |
+| aep.connection.proxy.user         | username for the proxy host                     |                                                         | no       |                         |
+| aep.connection.proxy.password     | password for the proxy host                     |                                                         | no       |                         |
 | aep.connection.auth.enabled       | required for authenticated streaming endpoint   | false                                                   | no       |                         |
 | aep.connection.auth.token.type    | always set to access_token                      | access_token                                            | no       |                         |
 | aep.connection.auth.client.id     | IMS client id                                   |                                                         | no       |                         |

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -35,7 +35,7 @@ AEP Sink connector configurations can be supplied in the call register the conne
 | value.converter.schemas.enable    | enables conversion of schemas                   | false                                                   | no       |                         |
 | aep.endpoint                      | aep streaming endpoint url                      |                                                         | yes      |                         |
 | aep.connection.proxy.host         | address of the proxy host to connect through    |                                                         | no       |                         |
-| aep.connection.proxy.port         | port of the proxy host to connect through       |                                                         | no       |                         |
+| aep.connection.proxy.port         | port of the proxy host to connect through       | 443                                                     | no       |                         |
 | aep.connection.proxy.user         | username for the proxy host                     |                                                         | no       |                         |
 | aep.connection.proxy.password     | password for the proxy host                     |                                                         | no       |                         |
 | aep.connection.auth.enabled       | required for authenticated streaming endpoint   | false                                                   | no       |                         |
@@ -284,6 +284,20 @@ curl -s -X POST \
   }
 }' http://localhost:8083/connectors
 ```
+
+#### Poxy host configuration
+There are 2 ways to route request to aep endpoint through proxy server :
+1. **Using Environment Variable** : Export poxyHost and proxyPort on each kafka node, then restart kafka connect node.
+    ```
+    export KAFKA_OPTS="-Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=8085 -Dhttp.proxyUser=proxyUsername -Dhttp.proxyPassword=proxyPassword"
+    ``` 
+2. **Using Connector Properties** : While creating connector set following properties, default values mentioned in [connect configurations](#configuration-options).
+    ```
+    aep.connection.proxy.host                                                          
+    aep.connection.proxy.port
+    aep.connection.proxy.user
+    aep.connection.proxy.password
+    ```
 
 #### Use the Kafka Topics UI to view your topics
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -288,8 +288,14 @@ curl -s -X POST \
 #### Poxy host configuration
 There are 2 ways to route request to aep endpoint through proxy server :
 1. **Using Environment Variable** : Export poxyHost and proxyPort on each kafka node, then restart kafka connect node.
+   
+    For HTTPS use following :
     ```
-    export KAFKA_OPTS="-Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=8085 -Dhttp.proxyUser=proxyUsername -Dhttp.proxyPassword=proxyPassword"
+    export KAFKA_OPTS="-Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=8085 -Dhttps.proxyUser=proxyUsername -Dhttps.proxyPassword=proxyPassword"
+    ``` 
+    For HTTP use following:
+    ```
+    export KAFKA_OPTS="-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=8085 -Dhttp.proxyUser=proxyUsername -Dhttp.proxyPassword=proxyPassword"
     ``` 
 2. **Using Connector Properties** : While creating connector set following properties, default values mentioned in [connect configurations](#configuration-options).
     ```
@@ -298,6 +304,7 @@ There are 2 ways to route request to aep endpoint through proxy server :
     aep.connection.proxy.user
     aep.connection.proxy.password
     ```
+For reference, more details are in oracle documentation on configuring proxy settings in java : https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html
 
 #### Use the Kafka Topics UI to view your topics
 

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
@@ -14,6 +14,8 @@ package com.adobe.platform.streaming.http;
 
 import com.adobe.platform.streaming.auth.AuthException;
 import com.adobe.platform.streaming.auth.AuthProvider;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +50,7 @@ public class HttpConnection {
   private String url;
 
   private String proxyHost;
-  private String proxyPort;
+  private int proxyPort;
   private String proxyUser;
   private String proxyPassword;
 
@@ -96,7 +98,7 @@ public class HttpConnection {
           }
 
           LOG.debug("proxyHost: {}, proxyPort: {}", proxyHost, proxyPort);
-          final Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
+          final Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
           conn = (HttpURLConnection) request.openConnection(proxy);
         } else {
           conn = (HttpURLConnection) request.openConnection();
@@ -207,14 +209,12 @@ public class HttpConnection {
   }
 
   public boolean isBasicProxyConfigured() {
-    return (proxyHost != null && !proxyHost.isEmpty()) &&
-        (proxyPort != null && !proxyPort.isEmpty());
+    return StringUtils.isNotEmpty(proxyHost);
   }
 
   public boolean isProxyWithAuthenticationConfigured() {
-    return isBasicProxyConfigured() &&
-        (proxyUser != null && !proxyUser.isEmpty()) &&
-        (proxyPassword != null && !proxyPassword.isEmpty());
+    return StringUtils.isNotEmpty(proxyUser) &&
+           StringUtils.isNotEmpty(proxyPassword);
   }
 
   public InputStream getInputStream() throws HttpException {
@@ -251,7 +251,7 @@ public class HttpConnection {
       return this;
     }
 
-    HttpConnectionBuilder withProxyPort(String proxyPort) {
+    HttpConnectionBuilder withProxyPort(int proxyPort) {
       instance.proxyPort = proxyPort;
       return this;
     }

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
@@ -79,12 +79,12 @@ public class HttpConnection {
 
     while (retries++ < maxRetries) {
       try {
-        URL request = new URL(new URL(endpoint), url);
+        final URL request = new URL(new URL(endpoint), url);
         LOG.debug("opening connection for: {}", request);
 
         if (isBasicProxyConfigured()) {
           if (isProxyWithAuthenticationConfigured()) {
-            LOG.debug("proxyUser: {}, proxyPassword: {}", proxyHost, proxyPassword);
+            LOG.debug("proxyUser: {}, proxyPassword: {}", proxyUser, proxyPassword);
             Authenticator.setDefault(
               new Authenticator() {
                 @Override
@@ -96,7 +96,7 @@ public class HttpConnection {
           }
 
           LOG.debug("proxyHost: {}, proxyPort: {}", proxyHost, proxyPort);
-          Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
+          final Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
           conn = (HttpURLConnection) request.openConnection(proxy);
         } else {
           conn = (HttpURLConnection) request.openConnection();

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpConnection.java
@@ -84,8 +84,9 @@ public class HttpConnection {
 
         if (isBasicProxyConfigured()) {
           if (isProxyWithAuthenticationConfigured()) {
+            LOG.debug("proxyUser: {}, proxyPassword: {}", proxyHost, proxyPassword);
             Authenticator.setDefault(
-                new Authenticator() {
+              new Authenticator() {
                 @Override
                 protected PasswordAuthentication getPasswordAuthentication() {
                   return new PasswordAuthentication(proxyUser, proxyPassword.toCharArray());
@@ -94,6 +95,7 @@ public class HttpConnection {
             );
           }
 
+          LOG.debug("proxyHost: {}, proxyPort: {}", proxyHost, proxyPort);
           Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
           conn = (HttpURLConnection) request.openConnection(proxy);
         } else {
@@ -205,14 +207,14 @@ public class HttpConnection {
   }
 
   public boolean isBasicProxyConfigured() {
-    return (proxyHost != null && !proxyHost.isEmpty())
-            && (proxyPort != null && !proxyPort.isEmpty());
+    return (proxyHost != null && !proxyHost.isEmpty()) &&
+        (proxyPort != null && !proxyPort.isEmpty());
   }
 
   public boolean isProxyWithAuthenticationConfigured() {
-    return isBasicProxyConfigured()
-            && (proxyUser != null && !proxyUser.isEmpty())
-            && (proxyPassword != null && !proxyPassword.isEmpty());
+    return isBasicProxyConfigured() &&
+        (proxyUser != null && !proxyUser.isEmpty()) &&
+        (proxyPassword != null && !proxyPassword.isEmpty());
   }
 
   public InputStream getInputStream() throws HttpException {

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
@@ -82,7 +82,7 @@ public class HttpProducer implements Serializable {
     return new HttpConnection.HttpConnectionBuilder()
       .withEndpoint(endpoint)
       .withProxyHost(proxyHost)
-      .withProxyPort(proxyHost)
+      .withProxyPort(proxyPort)
       .withProxyUser(proxyUser)
       .withProxyPassword(proxyPassword)
       .withConnectTimeout(connectTimeout)

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
@@ -32,7 +32,7 @@ public class HttpProducer implements Serializable {
   private final String endpoint;
 
   private String proxyHost;
-  private String proxyPort;
+  private int proxyPort;
   private String proxyUser;
   private String proxyPassword;
 
@@ -111,7 +111,7 @@ public class HttpProducer implements Serializable {
       return this;
     }
 
-    public HttpProducerBuilder withProxyPort(String proxyPort) {
+    public HttpProducerBuilder withProxyPort(int proxyPort) {
       instance.proxyPort = proxyPort;
       return this;
     }

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/HttpProducer.java
@@ -30,6 +30,12 @@ public class HttpProducer implements Serializable {
   private static final String CONTENT_TYPE = "Content-type";
 
   private final String endpoint;
+
+  private String proxyHost;
+  private String proxyPort;
+  private String proxyUser;
+  private String proxyPassword;
+
   private final boolean enableGzip;
   private int connectTimeout;
   private transient AuthProvider auth;
@@ -75,6 +81,10 @@ public class HttpProducer implements Serializable {
   private HttpConnection.HttpConnectionBuilder newConnectionBuilder() {
     return new HttpConnection.HttpConnectionBuilder()
       .withEndpoint(endpoint)
+      .withProxyHost(proxyHost)
+      .withProxyPort(proxyHost)
+      .withProxyUser(proxyUser)
+      .withProxyPassword(proxyPassword)
       .withConnectTimeout(connectTimeout)
       .withAuth(auth)
       .withReadTimeout(readTimeout)
@@ -94,6 +104,26 @@ public class HttpProducer implements Serializable {
 
     HttpProducerBuilder(HttpProducer instance) {
       this.instance = instance;
+    }
+
+    public HttpProducerBuilder withProxyHost(String proxyHost) {
+      instance.proxyHost = proxyHost;
+      return this;
+    }
+
+    public HttpProducerBuilder withProxyPort(String proxyPort) {
+      instance.proxyPort = proxyPort;
+      return this;
+    }
+
+    public HttpProducerBuilder withProxyUser(String proxyUser) {
+      instance.proxyUser = proxyUser;
+      return this;
+    }
+
+    public HttpProducerBuilder withProxyPassword(String proxyPassword) {
+      instance.proxyPassword = proxyPassword;
+      return this;
     }
 
     public HttpProducerBuilder withReadTimeout(int readTimeout) {

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractAEPPublisher.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractAEPPublisher.java
@@ -38,6 +38,12 @@ public abstract class AbstractAEPPublisher implements DataPublisher {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractAEPPublisher.class);
 
   private static final String AEP_ENDPOINT = "aep.endpoint";
+
+  private static final String AEP_CONNECTION_PROXY_HOST = "aep.connection.proxy.host";
+  private static final String AEP_CONNECTION_PROXY_PORT = "aep.connection.proxy.port";
+  private static final String AEP_CONNECTION_PROXY_USER = "aep.connection.proxy.user";
+  private static final String AEP_CONNECTION_PROXY_PASSWORD = "aep.connection.proxy.password";
+
   private static final String AEP_CONNECTION_TIMEOUT = "aep.connection.timeout";
   private static final String AEP_CONNECTION_MAX_RETRIES = "aep.connection.maxRetries";
   private static final String AEP_CONNECTION_MAX_RETRIES_BACKOFF = "aep.connection.retryBackoff";
@@ -62,6 +68,10 @@ public abstract class AbstractAEPPublisher implements DataPublisher {
 
   protected HttpProducer getHttpProducer(Map<String, String> props) throws AEPStreamingException {
     return HttpProducer.newBuilder(getAepEndpoint(props.get(AEP_ENDPOINT)))
+      .withProxyHost(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_HOST, null))
+      .withProxyPort(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_PORT, null))
+      .withProxyUser(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_USER, null))
+      .withProxyPassword(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_PASSWORD, null))
       .withConnectTimeout(SinkUtils.getProperty(props, AEP_CONNECTION_TIMEOUT, 5000))
       .withReadTimeout(SinkUtils.getProperty(props, AEP_CONNECTION_READ_TIMEOUT, 60000))
       .withMaxRetries(SinkUtils.getProperty(props, AEP_CONNECTION_MAX_RETRIES, 3))

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractAEPPublisher.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractAEPPublisher.java
@@ -69,7 +69,7 @@ public abstract class AbstractAEPPublisher implements DataPublisher {
   protected HttpProducer getHttpProducer(Map<String, String> props) throws AEPStreamingException {
     return HttpProducer.newBuilder(getAepEndpoint(props.get(AEP_ENDPOINT)))
       .withProxyHost(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_HOST, null))
-      .withProxyPort(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_PORT, null))
+      .withProxyPort(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_PORT, 443))
       .withProxyUser(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_USER, null))
       .withProxyPassword(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_PASSWORD, null))
       .withConnectTimeout(SinkUtils.getProperty(props, AEP_CONNECTION_TIMEOUT, 5000))

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -85,6 +85,8 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
     // Verify inlet endpoint received 1 XDM record
     getWiremockServerViaProxy().verify(postRequestedFor(urlEqualTo(getRelativeUrl()))
       .withRequestBody(equalToJson(payloadReceivedXdmData())));
+    // Check if request from proxy server forward to AEP endpoint
+    getWiremockServer().verify(postRequestedFor(urlEqualTo(getRelativeUrl())));
   }
 
   @AfterEach

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -124,7 +124,8 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
     String connectorProperties = String.format(HttpUtil.streamToString(this.getClass().getClassLoader()
       .getResourceAsStream(AEP_CONNECTOR_CONFIG_WITH_PROXY)),
       NUMBER_OF_TASKS,
-      getInletUrl());
+      getInletUrl(),
+      PORT_VIA_PROXY);
 
     Map<String, String> connectorConfig = MAPPER.readValue(connectorProperties,
       new TypeReference<Map<String, String>>() {});

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -124,7 +124,7 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
     String connectorProperties = String.format(HttpUtil.streamToString(this.getClass().getClassLoader()
       .getResourceAsStream(AEP_CONNECTOR_CONFIG_WITH_PROXY)),
       NUMBER_OF_TASKS,
-      getInletUrlViaProxy());
+      getInletUrl());
 
     Map<String, String> connectorConfig = MAPPER.readValue(connectorProperties,
       new TypeReference<Map<String, String>>() {});

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
@@ -145,10 +145,6 @@ public abstract class AbstractConnectorTest {
     return baseUrl.concat(relativePath);
   }
 
-  protected String getInletUrlViaProxy() {
-    return baseUrlViaProxy.concat(relativePath);
-  }
-
   public int getNumberOfWorkers() {
     return numberOfWorkers;
   }

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
@@ -55,7 +55,6 @@ public abstract class AbstractConnectorTest {
   private int numberOfWorkers = 1;
   private String inletId = "876e1041c16801b8b3038ec86bb4510e8c89356152191b587367b592e79d91d5";
   private String baseUrl;
-  private String baseUrlViaProxy;
   private String relativePath;
 
   @RegisterExtension
@@ -75,7 +74,6 @@ public abstract class AbstractConnectorTest {
         .build();
     connect.start();
     baseUrl = String.format("http://localhost:%s", PORT);
-    baseUrlViaProxy = String.format("http://localhost:%s", PORT_VIA_PROXY);
     relativePath = String.format("/collection/%s", inletId);
   }
 
@@ -115,7 +113,7 @@ public abstract class AbstractConnectorTest {
       .withJsonBody(MAPPER.readTree("{\"payloadReceived\": true}"))));
   }
 
-  public void inletSuccessfulResponseViaProxy() throws JsonProcessingException {
+  public void inletSuccessfulResponseViaProxy() {
     wiremockExtensionViaProxy.getWireMockServer()
       .stubFor(WireMock
       .post(WireMock.urlEqualTo(getRelativeUrl()))

--- a/streaming-connect-sink/src/test/resources/aep-connector-with-proxy.json
+++ b/streaming-connect-sink/src/test/resources/aep-connector-with-proxy.json
@@ -8,5 +8,5 @@
   "value.converter.schemas.enable": "false",
   "aep.endpoint": "%s",
   "aep.connection.proxy.host": "localhost",
-  "aep.connection.proxy.port": "8090"
+  "aep.connection.proxy.port": "%s"
 }

--- a/streaming-connect-sink/src/test/resources/aep-connector-with-proxy.json
+++ b/streaming-connect-sink/src/test/resources/aep-connector-with-proxy.json
@@ -1,0 +1,12 @@
+{
+  "topics": "connect-test",
+  "tasks.max": "%s",
+  "aep.flush.interval.seconds": "1",
+  "aep.flush.bytes.kb": "4",
+  "connector.class": "com.adobe.platform.streaming.sink.impl.AEPSinkConnector",
+  "key.converter.schemas.enable": "false",
+  "value.converter.schemas.enable": "false",
+  "aep.endpoint": "%s",
+  "aep.connection.proxy.host": "localhost",
+  "aep.connection.proxy.port": "8090"
+}


### PR DESCRIPTION
## Summary
Added support for http proxy to the connector configuration. This allows the user to add proxy host details when using the connector within a corporate environment having proxy host.

## Related Issue
#26 

## Changes
Added support for http proxy with the following connector configuration

* aep.connection.proxy.host: address of the proxy host to connect through
* aep.connection.proxy.port: port of the proxy host to connect through
* aep.connection.proxy.user: username for the proxy host
* aep.connection.proxy.password: password for the proxy host

## Relevant Documentation

DEVELOPER_GUIDE.md

## How Has This Been Tested?
* Added a new test case aepSinkConnectorTestViaProxy() to the existing test suite. To execute this test case, have setup a new mock extention wiremockExtensionViaProxy which acts as a proxy server to redirect the request to the actual wiremockExtension.
* Test locally by using local proxy server and pointing to AEP endpoint

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
