### PR TITLE
Provides a mechanism to give the value of a key to the connect configuration. See issue #45

### DIFF
--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/auth/AuthUtils.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/auth/AuthUtils.java
@@ -12,10 +12,12 @@
 
 package com.adobe.platform.streaming.auth;
 
+import com.adobe.platform.streaming.utils.AbstractStreamingUtils;
+
 /**
  * @author Adobe Inc.
  */
-public final class AuthUtils {
+public final class AuthUtils extends AbstractStreamingUtils {
 
   public static final String AUTH_ENDPOINT = "AUTH_ENDPOINT";
   public static final String AUTH_CLIENT_ID = "auth.client.id";
@@ -26,6 +28,7 @@ public final class AuthUtils {
   public static final String AUTH_TECHNICAL_ACCOUNT_ID = "auth.client.technicalAccountKey";
   public static final String AUTH_META_SCOPE = "auth.client.metaScope";
   public static final String AUTH_PRIVATE_KEY_FILE_PATH = "auth.client.filePath";
+  public static final String AUTH_PRIVATE_KEY_VALUE = "auth.client.keyValue";
 
   private AuthUtils() {}
 }

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/auth/impl/AuthProviderFactory.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/auth/impl/AuthProviderFactory.java
@@ -68,16 +68,18 @@ public final class AuthProviderFactory {
     final String imsOrgId = authProperties.get(AuthUtils.AUTH_IMS_ORG_ID);
     final String technicalAccountKey = authProperties.get(AuthUtils.AUTH_TECHNICAL_ACCOUNT_ID);
     final String filePath = authProperties.get(AuthUtils.AUTH_PRIVATE_KEY_FILE_PATH);
+    final String keyValue = authProperties.get(AuthUtils.AUTH_PRIVATE_KEY_VALUE);
 
     Preconditions.checkNotNull(clientId, "Invalid client Id");
     Preconditions.checkNotNull(clientSecret, "Invalid client secret.");
     Preconditions.checkNotNull(imsOrgId, "Invalid IMS Org");
     Preconditions.checkNotNull(technicalAccountKey, "Invalid technical account Id");
 
+
     String endpoint = authProperties.get(AuthUtils.AUTH_ENDPOINT);
     return StringUtils.isEmpty(endpoint) ?
-      new JWTTokenProvider(clientId, clientSecret, imsOrgId, technicalAccountKey, filePath, authProxyConfiguration) :
-      new JWTTokenProvider(endpoint, clientId, clientSecret, imsOrgId, technicalAccountKey, filePath,
+      new JWTTokenProvider(clientId, clientSecret, imsOrgId, technicalAccountKey, filePath, keyValue, authProxyConfiguration) :
+      new JWTTokenProvider(endpoint, clientId, clientSecret, imsOrgId, technicalAccountKey, filePath, keyValue,
         authProxyConfiguration);
   }
 

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/auth/impl/AuthProviderFactory.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/auth/impl/AuthProviderFactory.java
@@ -75,12 +75,12 @@ public final class AuthProviderFactory {
     Preconditions.checkNotNull(imsOrgId, "Invalid IMS Org");
     Preconditions.checkNotNull(technicalAccountKey, "Invalid technical account Id");
 
-
     String endpoint = authProperties.get(AuthUtils.AUTH_ENDPOINT);
     return StringUtils.isEmpty(endpoint) ?
-      new JWTTokenProvider(clientId, clientSecret, imsOrgId, technicalAccountKey, filePath, keyValue, authProxyConfiguration) :
-      new JWTTokenProvider(endpoint, clientId, clientSecret, imsOrgId, technicalAccountKey, filePath, keyValue,
-        authProxyConfiguration);
+      new JWTTokenProvider(clientId, clientSecret, imsOrgId, technicalAccountKey,
+              filePath, keyValue, authProxyConfiguration) :
+      new JWTTokenProvider(endpoint, clientId, clientSecret, imsOrgId, technicalAccountKey,
+              filePath, keyValue, authProxyConfiguration);
   }
 
   private AuthProviderFactory() {}

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/utils/AbstractStreamingUtils.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/utils/AbstractStreamingUtils.java
@@ -1,37 +1,47 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
 package com.adobe.platform.streaming.utils;
 
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
+/**
+ * @author Adobe Inc.
+ */
 public abstract class AbstractStreamingUtils {
-
-
-
-    public static int getProperty(Map<String, String> props, String propertyName, int defaultValue) {
-        if (props != null) {
-            String propertyValue = props.get(propertyName);
-            if (StringUtils.isNotBlank(propertyValue)) {
-                return Integer.parseInt(propertyValue);
-            }
-        }
-
-        return defaultValue;
+  public static int getProperty(Map<String, String> props, String propertyName, int defaultValue) {
+    if (props != null) {
+      String propertyValue = props.get(propertyName);
+      if (StringUtils.isNotBlank(propertyValue)) {
+        return Integer.parseInt(propertyValue);
+      }
     }
+    return defaultValue;
+  }
 
-    public static String getProperty(Map<String, String> props, String propertyName, String defaultValue) {
-        return props != null ? (StringUtils.isNotBlank(props.get(propertyName)) ? props.get(propertyName) : defaultValue)
-                : defaultValue;
+  public static String getProperty(Map<String, String> props, String propertyName, String defaultValue) {
+    return props != null ? (StringUtils.isNotBlank(props.get(propertyName)) ? props.get(propertyName) : defaultValue)
+            : defaultValue;
+  }
+
+  public static int getProperty(Map<String, String> properties, String key, int defaultValue, int multiplier) {
+    int propertyValue = getProperty(properties, key, defaultValue) * multiplier;
+    if (propertyValue < 1) {
+      return defaultValue * multiplier;
     }
-
-    public static int getProperty(Map<String, String> properties, String key, int defaultValue, int multiplier) {
-        int propertyValue = getProperty(properties, key, defaultValue) * multiplier;
-        if (propertyValue < 1) {
-            return defaultValue * multiplier;
-        }
-
-        return propertyValue;
-    }
+    return propertyValue;
+  }
 
 }
 

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/utils/AbstractStreamingUtils.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/utils/AbstractStreamingUtils.java
@@ -1,0 +1,37 @@
+package com.adobe.platform.streaming.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+
+public abstract class AbstractStreamingUtils {
+
+
+
+    public static int getProperty(Map<String, String> props, String propertyName, int defaultValue) {
+        if (props != null) {
+            String propertyValue = props.get(propertyName);
+            if (StringUtils.isNotBlank(propertyValue)) {
+                return Integer.parseInt(propertyValue);
+            }
+        }
+
+        return defaultValue;
+    }
+
+    public static String getProperty(Map<String, String> props, String propertyName, String defaultValue) {
+        return props != null ? (StringUtils.isNotBlank(props.get(propertyName)) ? props.get(propertyName) : defaultValue)
+                : defaultValue;
+    }
+
+    public static int getProperty(Map<String, String> properties, String key, int defaultValue, int multiplier) {
+        int propertyValue = getProperty(properties, key, defaultValue) * multiplier;
+        if (propertyValue < 1) {
+            return defaultValue * multiplier;
+        }
+
+        return propertyValue;
+    }
+
+}
+

--- a/streaming-connect-common/src/test/java/com/adobe/platform/streaming/auth/impl/JWTTokenProviderTest.java
+++ b/streaming-connect-common/src/test/java/com/adobe/platform/streaming/auth/impl/JWTTokenProviderTest.java
@@ -70,9 +70,8 @@ class JWTTokenProviderTest {
   @Test
   void testGetTokenValidKeyValueNoPath() {
     JWTTokenProvider tokenProvider = new JWTTokenProvider(ENDPOINT, TEST_ORG, TEST_CLIENT,
-            TEST_ACCOUNT_ID, TEST_FILE_PATH, TEST_KEY_VALUE, AuthProxyConfiguration.builder().build());
+      TEST_ACCOUNT_ID, TEST_FILE_PATH, TEST_KEY_VALUE, AuthProxyConfiguration.builder().build());
     assertThrows(AuthException.class, tokenProvider::getToken);
   }
-
 
 }

--- a/streaming-connect-common/src/test/java/com/adobe/platform/streaming/auth/impl/JWTTokenProviderTest.java
+++ b/streaming-connect-common/src/test/java/com/adobe/platform/streaming/auth/impl/JWTTokenProviderTest.java
@@ -30,40 +30,49 @@ class JWTTokenProviderTest {
     JWTTokenProviderTest.class.getClassLoader().getResource("secret.key").getPath();
   private static final String TEST_INVALID_FILE_PATH =
     JWTTokenProviderTest.class.getClassLoader().getResource("secret_invalid.key").getPath();
+  private static final String TEST_KEY_VALUE = "test-key";
 
   @Test
   void testGetTokenWithInvalidIMSOrg() {
     JWTTokenProvider tokenProvider = new JWTTokenProvider(ENDPOINT, null, TEST_CLIENT, TEST_ACCOUNT_ID,
-      TEST_FILE_PATH, AuthProxyConfiguration.builder().build());
+      TEST_FILE_PATH, TEST_KEY_VALUE, AuthProxyConfiguration.builder().build());
     assertThrows(AuthException.class, tokenProvider::getToken);
   }
 
   @Test
   void testGetTokenWithInvalidClientId() {
     JWTTokenProvider tokenProvider = new JWTTokenProvider(ENDPOINT, TEST_ORG, null, TEST_ACCOUNT_ID,
-      TEST_FILE_PATH, AuthProxyConfiguration.builder().build());
+      TEST_FILE_PATH, TEST_KEY_VALUE, AuthProxyConfiguration.builder().build());
     assertThrows(AuthException.class, tokenProvider::getToken);
   }
 
   @Test
   void testGetTokenWithInvalidAccountId() {
     JWTTokenProvider tokenProvider = new JWTTokenProvider(ENDPOINT, TEST_ORG, TEST_CLIENT, null,
-      TEST_FILE_PATH, AuthProxyConfiguration.builder().build());
+      TEST_FILE_PATH, TEST_KEY_VALUE, AuthProxyConfiguration.builder().build());
     assertThrows(AuthException.class, tokenProvider::getToken);
   }
 
   @Test
   void testGetTokenInvalidPath() {
     JWTTokenProvider tokenProvider = new JWTTokenProvider(ENDPOINT, TEST_ORG, TEST_CLIENT,
-      TEST_ACCOUNT_ID, TEST_INVALID_FILE_PATH, AuthProxyConfiguration.builder().build());
+      TEST_ACCOUNT_ID, TEST_INVALID_FILE_PATH, TEST_KEY_VALUE, AuthProxyConfiguration.builder().build());
     assertThrows(AuthException.class, tokenProvider::getToken);
   }
 
   @Test
   void testGetTokenValidPath() {
     JWTTokenProvider tokenProvider = new JWTTokenProvider(ENDPOINT, TEST_ORG, TEST_CLIENT,
-      TEST_ACCOUNT_ID, TEST_FILE_PATH, AuthProxyConfiguration.builder().build());
+      TEST_ACCOUNT_ID, TEST_FILE_PATH, TEST_KEY_VALUE, AuthProxyConfiguration.builder().build());
     assertThrows(AuthException.class, tokenProvider::getToken);
   }
+
+  @Test
+  void testGetTokenValidKeyValueNoPath() {
+    JWTTokenProvider tokenProvider = new JWTTokenProvider(ENDPOINT, TEST_ORG, TEST_CLIENT,
+            TEST_ACCOUNT_ID, TEST_FILE_PATH, TEST_KEY_VALUE, AuthProxyConfiguration.builder().build());
+    assertThrows(AuthException.class, tokenProvider::getToken);
+  }
+
 
 }

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractAEPPublisher.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractAEPPublisher.java
@@ -64,6 +64,7 @@ public abstract class AbstractAEPPublisher implements DataPublisher {
 
   private static final String AEP_CONNECTION_AUTH_ENABLED_VALUE = "true";
   private static final String AEP_CONNECTION_AUTH_DISABLED_VALUE = "false";
+  private static final String AEP_CONNECTION_AUTH_KEY_VALUE = "aep.connection.auth.keyValue";
 
   protected HttpProducer getHttpProducer(Map<String, String> props) throws AEPStreamingException {
     return HttpProducer.newBuilder(getAepEndpoint(props.get(AEP_ENDPOINT)))
@@ -133,13 +134,15 @@ public abstract class AbstractAEPPublisher implements DataPublisher {
   }
 
   private AuthProvider getJWTTokenProvider(Map<String, String> props) throws AuthException {
+
     return AuthProviderFactory.getAuthProvider(TokenType.JWT_TOKEN, ImmutableMap.<String, String>builder()
       .put(AuthUtils.AUTH_CLIENT_ID, props.get(AEP_CONNECTION_AUTH_CLIENT_ID))
       .put(AuthUtils.AUTH_CLIENT_SECRET, props.get(AEP_CONNECTION_AUTH_CLIENT_SECRET))
       .put(AuthUtils.AUTH_ENDPOINT, props.get(AEP_CONNECTION_AUTH_ENDPOINT))
       .put(AuthUtils.AUTH_IMS_ORG_ID, props.get(AEP_CONNECTION_AUTH_IMS_ORG))
       .put(AuthUtils.AUTH_TECHNICAL_ACCOUNT_ID, props.get(AEP_CONNECTION_AUTH_ACCOUNT_KEY))
-      .put(AuthUtils.AUTH_PRIVATE_KEY_FILE_PATH, props.get(AEP_CONNECTION_AUTH_FILE_PATH))
+      .put(AuthUtils.AUTH_PRIVATE_KEY_FILE_PATH, AuthUtils.getProperty(props, AEP_CONNECTION_AUTH_FILE_PATH, ""))
+      .put(AuthUtils.AUTH_PRIVATE_KEY_VALUE, AuthUtils.getProperty(props, AEP_CONNECTION_AUTH_KEY_VALUE, ""))
       .build(), AuthProxyConfiguration.builder()
       .proxyHost(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_HOST, null))
       .proxyPort(SinkUtils.getProperty(props, AEP_CONNECTION_PROXY_PORT, 443))

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractSinkConnector.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractSinkConnector.java
@@ -13,6 +13,7 @@
 package com.adobe.platform.streaming.sink;
 
 import com.google.common.collect.ImmutableMap;
+import kafka.server.ConfigType;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.sink.SinkConnector;
@@ -48,6 +49,7 @@ public abstract class AbstractSinkConnector extends SinkConnector {
     List<Map<String, String>> configs = new ArrayList<>();
     for (int i = 0; i < maxTasks; i++) {
       configs.add(new ImmutableMap.Builder<String, String>().putAll(connectorProps).build());
+
     }
 
     return configs;
@@ -60,6 +62,11 @@ public abstract class AbstractSinkConnector extends SinkConnector {
 
   @Override
   public ConfigDef config() {
+
+
+
+    ConfigDef configDef = new ConfigDef();
+    configDef.define("aep.connection.auth.keyValue", ConfigDef.Type.PASSWORD,null,null,"");
     return new ConfigDef();
   }
 

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractSinkConnector.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/AbstractSinkConnector.java
@@ -13,7 +13,6 @@
 package com.adobe.platform.streaming.sink;
 
 import com.google.common.collect.ImmutableMap;
-import kafka.server.ConfigType;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.sink.SinkConnector;

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/utils/SinkUtils.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/utils/SinkUtils.java
@@ -12,6 +12,7 @@
 
 package com.adobe.platform.streaming.sink.utils;
 
+import com.adobe.platform.streaming.utils.AbstractStreamingUtils;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang3.StringUtils;
@@ -22,7 +23,7 @@ import java.util.Map;
 /**
  * @author Adobe Inc.
  */
-public class SinkUtils {
+public class SinkUtils extends AbstractStreamingUtils {
 
   public static String getStringPayload(Gson gson, SinkRecord record) {
     if (record.value() instanceof String) {
@@ -32,30 +33,7 @@ public class SinkUtils {
     return gson.toJson(record.value());
   }
 
-  public static int getProperty(Map<String, String> props, String propertyName, int defaultValue) {
-    if (props != null) {
-      String propertyValue = props.get(propertyName);
-      if (StringUtils.isNotBlank(propertyValue)) {
-        return Integer.parseInt(propertyValue);
-      }
-    }
 
-    return defaultValue;
-  }
-
-  public static String getProperty(Map<String, String> props, String propertyName, String defaultValue) {
-    return props != null ? (StringUtils.isNotBlank(props.get(propertyName)) ? props.get(propertyName) : defaultValue)
-      : defaultValue;
-  }
-
-  public static int getProperty(Map<String, String> properties, String key, int defaultValue, int multiplier) {
-    int propertyValue = getProperty(properties, key, defaultValue) * multiplier;
-    if (propertyValue < 1) {
-      return defaultValue * multiplier;
-    }
-
-    return propertyValue;
-  }
 
   private SinkUtils() {
   }

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -165,7 +165,8 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
 
   @Test
   public void aepSinkConnectorJWTAuthenticationProxyTestFromKeyValue() throws HttpException, JsonProcessingException,
-          InterruptedException {
+      InterruptedException {
+
     inletJWTAuthenticationSuccessfulResponse();
     inletJWTAuthenticationSuccessfulResponseViaProxy();
 
@@ -251,18 +252,13 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
   }
 
   public Map<String, String> connectorConfigWithJWTConfigProxyFromKey() throws HttpException, JsonProcessingException {
-
-
-
     String connectorProperties = String.format(HttpUtil.streamToString(this.getClass().getClassLoader()
-                    .getResourceAsStream(AEP_CONNECTOR_JWT_AUTH_CONFIG_WITH_KEY)),
-            NUMBER_OF_TASKS,
-            getInletUrl(),
-            getBaseUrl());
-
-
+      .getResourceAsStream(AEP_CONNECTOR_JWT_AUTH_CONFIG_WITH_KEY)),
+      NUMBER_OF_TASKS,
+      getInletUrl(),
+      getBaseUrl());
     Map<String, String> connectorConfig = MAPPER.readValue(connectorProperties,
-            new TypeReference<Map<String, String>>() {});
+      new TypeReference<Map<String, String>>() {});
     connectorConfig.put("name", CONNECTOR_NAME);
     return connectorConfig;
   }

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;

--- a/streaming-connect-sink/src/test/resources/aep-connector-with-jwt-token-with-key.json
+++ b/streaming-connect-sink/src/test/resources/aep-connector-with-jwt-token-with-key.json
@@ -1,0 +1,18 @@
+{
+  "topics": "connect-test",
+  "tasks.max": "%s",
+  "aep.flush.interval.seconds": "1",
+  "aep.flush.bytes.kb": "4",
+  "connector.class": "com.adobe.platform.streaming.sink.impl.AEPSinkConnector",
+  "key.converter.schemas.enable": "false",
+  "value.converter.schemas.enable": "false",
+  "aep.endpoint": "%s",
+  "aep.connection.auth.enabled": true,
+  "aep.connection.auth.endpoint": "%s",
+  "aep.connection.auth.token.type": "jwt_token",
+  "aep.connection.auth.client.id": "client_id",
+  "aep.connection.auth.client.secret": "client_secret",
+  "aep.connection.auth.imsOrg": "imsOrg@AdobeOrg",
+  "aep.connection.auth.accountKey": "technical-account-id",
+  "aep.connection.auth.keyValue":"MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDQ0YKnFrgZ47UK3wVm3YCJBAH/2hf0MTyRK1D+K/ycB46sKzhSC2sFXPsaQ9fiHzYKtqKZNEw6Jt9tgycSXZz49LfFeg4rdEot1RGvRo2A6Lof6ej5OVNRHnG7Hc31zblSrVPyMpRGY+l/BlJ1JWIIlQI7pvv+b0DgxJYXgbPc16k2zfAFJuKxA6dmD3mmMWuWAUO0kUhyIyYNf9PYEmp6lkRZ6F9HGT+zj4SI8FDhYey8GM2PurnEBLsbc2R10YFbS7bwsB1lI4CBiSYU74B9CVoQfGdkwDSt3trVPE8NfZemHAli+s1JWG/x70CU2gsMKvK0M310g3uk2dv7MwRxAgMBAAECggEAU/VI4MGDt/UT35EX7On2OiDAZQxdQTNitMODxw4MfPeU56hg9qvclcVyuHa6oBIIenpAGfUrCN6EStXGqd21tWs/UEjo1ZPmF1Npzt1BG6l23EoB/+KKmzzwYVl0a/YRIyrJa8HmV/7n7Miv8qXbKrQut6lF/GDi5vxjlIPzu0DItfqCe0s0DTlOzLjiuw7tnqNQzxdwivO+v7IDb+GA4inuttOhETc8qQZzGsnRbt7/eSnCKQ6MKtMNbKC4+iT1d/EJo+PtwP4wol/hvRWs5jPO7sgmGgDnxs5Nyz84GvV9OkHpx5msd2OPDF203BgCQacqaABTpIctFd954tsgAQKBgQDrdQ34fp7NujcEbEhRTnpccgPX42TtIjYsWelTO9QPIWJcT3xhsyh5WRWSug4/7z98acDrPJdDhTyuWU1g7KJD01vtq2gnAKiUnJoerGnXh7WnmwHO8QwHx6qeCL5CCTYUR1MYxooAbR3KhtSiG/oahOjHSta2fkZ8vcag5L9RAQKBgQDjCXnvHSlm+iDUbTgTLt/+PXRcsi3HV+O1uAK9cvGx9FlrK+DUH7jpoxkA2tzlPUnXSJi2K5IWsOLmlIEW61loqJNMyc2NYTxbrIB3iKCcT2GtHBZEGgVq3d4TZXD68cQK/9DZC9ye6mnM4gg+vSVcuNT33rKRPztKINZWU41DcQKBgA3V7AM9FYHLPm5hGoLElMYX4Qfvkb+pcft7MQ22B0j4UjpQZWOsTmWLCYx8qFezbEyYPkDUZ6MNEjrAfp6CaSqJIe6+Urlv/Xf2F8xTn0iN7euyXRHW8jkGz4zHwL5KokXgxw4+pF9QCh8beyUndbPXOYJ0cFd65hNwZ1qO9nsBAoGBAJfnej8DavUsfBTFctRa86G+6oEu8jRDWOb31FV/d7lSPRXYyNgE1Yr1BkCtL0juBd7WAt84Lcmi1l3ilLCKDUtaJxwklbR3j5Piyh2wO436CudxOHCeXGuRQQoHQF2Wr02QteLS7e0h+GIOBeg8U6hDPrMNvLoz7W5+pAokYwrxAoGBAJw+1kMFJEX8T1r1kj/3E+36Txg0Riac9zjA3FmE5DqW8MYSyiA0j3nJCqyAlyetUIh8r2QqdbfsXoiZS6o5ULA3I8pe/N2Yvw/s0WZBILtFyuq2Z6TP45Z4lm7YgnXA0jcs4Kaa7SU8yc7Bxw4MWRGz7LdX4ShRHkBR0HhwkcKD"
+}

--- a/streaming-connect-sink/src/test/resources/aep-connector-with-jwt-token.json
+++ b/streaming-connect-sink/src/test/resources/aep-connector-with-jwt-token.json
@@ -14,5 +14,5 @@
   "aep.connection.auth.client.secret": "client_secret",
   "aep.connection.auth.imsOrg": "imsOrg@AdobeOrg",
   "aep.connection.auth.accountKey": "technical-account-id",
-  "aep.connection.auth.filePath": "%s"
+  "aep.connection.auth.filePath": "C:/Users/u207754/Documents/git/ba-experience-platform-streaming-connect/BA-experience-platform-streaming-connect/streaming-connect-sink/build/resources/test/secret.key"
 }

--- a/streaming-connect-sink/src/test/resources/aep-connector-with-jwt-token.json
+++ b/streaming-connect-sink/src/test/resources/aep-connector-with-jwt-token.json
@@ -14,5 +14,5 @@
   "aep.connection.auth.client.secret": "client_secret",
   "aep.connection.auth.imsOrg": "imsOrg@AdobeOrg",
   "aep.connection.auth.accountKey": "technical-account-id",
-  "aep.connection.auth.filePath": "C:/Users/u207754/Documents/git/ba-experience-platform-streaming-connect/BA-experience-platform-streaming-connect/streaming-connect-sink/build/resources/test/secret.key"
+  "aep.connection.auth.filePath": "%s"
 }


### PR DESCRIPTION

## Summary
Adds the ability to provide a key value to connect configurations. This allows the use of a Kafka Config provider to provide key values for serverless use cases. Using a secure source for the config provider is essential. An example use-case is:

sink Connector -> Config provider -> AWS Secrets Manager Config Provider Implementation -> AWS secrets Manager Repo for storing and rotating keys

## Related Issue

#45 

## Changes


## Relevant Documentation

See here for an example use-case: https://docs.aws.amazon.com/msk/latest/developerguide/mkc-debeziumsource-connector-example.html

## How Has This Been Tested?
Added integration test. ensures existing config does not break
UAT on staging MSK connect cluster


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
