### PR TITLE
ISSUE-57 Add support for json patch transformation as connect SMT

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,6 +26,7 @@ versions.jmxPrometheusJavaAgent = '0.12.0'
 versions.junitJupiter = '5.2.0'
 versions.jjwt = '0.9.0'
 versions.orgJson = '20230227'
+versions.jsonPatch = '0.4.4'
 versions.kafkaConnect = '2.8.0'
 versions.slf4j = '1.7.25'
 versions.jaxb = '2.3.0'
@@ -96,6 +97,10 @@ libraries.kafkaConnectTest = [
 
 libraries.orgJson = [
   "org.json:json:$versions.orgJson"
+]
+
+libraries.jsonPatch = [
+  "com.flipkart.zjsonpatch:zjsonpatch:$versions.jsonPatch"
 ]
 
 libraries.slf4j = [

--- a/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/serializer/SerializerDeserializerUtil.java
+++ b/streaming-connect-common/src/main/java/com/adobe/platform/streaming/http/serializer/SerializerDeserializerUtil.java
@@ -57,4 +57,8 @@ public class SerializerDeserializerUtil {
   public static ObjectNode createObjectNode() {
     return MAPPER.createObjectNode();
   }
+
+  public static ObjectMapper getMapper() {
+    return MAPPER;
+  }
 }

--- a/streaming-connect-sink/build.gradle
+++ b/streaming-connect-sink/build.gradle
@@ -23,6 +23,7 @@ dependencies {
                  libraries.jackson, libraries.httpClient,
                  libraries.kafkaConnect, libraries.orgJson,
                  libraries.slf4j
+  implementation libraries.jsonPatch
   compileOnly libraries.kafkaConnectRuntime
   jmxAgent libraries.jmxPrometheusJavaAgent
   testImplementation libraries.jmockit, libraries.junitJupiter,

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/transformation/JsonPatchTransform.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/transformation/JsonPatchTransform.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.platform.streaming.sink.transformation;
+
+import com.adobe.platform.streaming.AEPStreamingRuntimeException;
+import com.adobe.platform.streaming.http.serializer.SerializerDeserializerUtil;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.flipkart.zjsonpatch.InvalidJsonPatchException;
+import com.flipkart.zjsonpatch.JsonPatch;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Adobe Inc.
+ */
+public class JsonPatchTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JsonPatchTransform.class);
+  private static final ObjectMapper MAPPER = SerializerDeserializerUtil.getMapper();
+  private static final ObjectNodeConverter objectNodeConverter = new ObjectNodeConverter(MAPPER);
+  private static final String JSON_PATCH_CONFIG = "operations";
+  private static final String JSON_PATHS_DOC = "Json pointers to evaluate for filtering";
+  private static final ConfigDef CONFIG_DEF = new ConfigDef().define(
+    JSON_PATCH_CONFIG,
+    ConfigDef.Type.STRING,
+    ConfigDef.NO_DEFAULT_VALUE,
+    ConfigDef.Importance.HIGH,
+    JSON_PATHS_DOC
+  );
+  private JsonNode jsonPatch;
+
+  @Override
+  public R apply(R record) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Received record in Patch Transformation {} ", record.value());
+    }
+
+    final Object value = record.value();
+    if (Objects.isNull(value)) {
+      return record;
+    }
+    try {
+      final ObjectNode jsonValue = objectNodeConverter.convert(value);
+      final JsonNode transformedValue = JsonPatch.apply(jsonPatch, jsonValue);
+      Object out = MAPPER.writeValueAsString(transformedValue);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Transformed record {}", jsonValue);
+      }
+      return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(),
+                              record.key(), record.valueSchema(), out, System.currentTimeMillis());
+    } catch (InvalidJsonPatchException patchAppException) {
+      LOG.error("Message validation failed.", patchAppException);
+    } catch (Exception ex) {
+      LOG.error("Record failed during transformation.", ex);
+    }
+    return record;
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    final SimpleConfig config = new SimpleConfig(CONFIG_DEF, configs);
+    try {
+      jsonPatch = MAPPER.readTree(config.getString(JSON_PATCH_CONFIG));
+    } catch (JsonProcessingException e) {
+      throw new AEPStreamingRuntimeException("Failed to read json patch config.", e);
+    }
+  }
+
+}

--- a/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/transformation/ObjectNodeConverter.java
+++ b/streaming-connect-sink/src/main/java/com/adobe/platform/streaming/sink/transformation/ObjectNodeConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.platform.streaming.sink.transformation;
+
+import com.adobe.platform.streaming.AEPStreamingRuntimeException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Adobe Inc.
+ */
+public class ObjectNodeConverter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ObjectNodeConverter.class);
+  private final ObjectMapper objectMapper;
+
+  public ObjectNodeConverter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public ObjectNode convert(Object from) {
+    if (Objects.isNull(from)) {
+      return null;
+    }
+    ObjectNode convertedVal = null;
+    try {
+      if (from instanceof String) {
+        convertedVal = (ObjectNode) objectMapper.readTree(from.toString());
+      } else if (from instanceof byte[]) {
+        convertedVal = (ObjectNode) objectMapper.readTree((byte[]) from);
+      } else if (from instanceof Map) {
+        convertedVal = objectMapper.convertValue(from, ObjectNode.class);
+      } else if (from instanceof ObjectNode) {
+        return (ObjectNode) from;
+      } else {
+        throw new AEPStreamingRuntimeException("Unsupported type for conversion to objectNode");
+      }
+    } catch (IOException e) {
+      LOG.error("Exception occurred while de-serializing to ObjectNode", e);
+    }
+    return convertedVal;
+  }
+
+}

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/unit/JsonPatchTransformTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/unit/JsonPatchTransformTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.platform.streaming.unit;
+
+import com.adobe.platform.streaming.http.serializer.SerializerDeserializerUtil;
+import com.adobe.platform.streaming.sink.transformation.JsonPatchTransform;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import mockit.Mocked;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.connect.data.Schema.Type.STRING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author Adobe Inc.
+ */
+public class JsonPatchTransformTest {
+
+  @Mocked
+  protected ConnectHeaders headers;
+
+  private final String jsonPatchString = "[\n" +
+    "  {\n" +
+    "    \"op\": \"add\",\n" +
+    "    \"path\": \"/header\",\n" +
+    "    \"value\": {\"operations\":{\"data\":\"merge\", \"identity\":\"create\", " +
+    "\"identityDatasetId\":\"2474b6c6c8bb6a1c72643ac8\"}}\n" +
+    "  }\n" +
+    "]";
+
+  private String recordObjectString = "{\n" +
+    "  \"payload\": {\n" +
+    "    \"crmId\": \"VM-121-SHARE\",\n" +
+    "    \"id\": 2388398\n" +
+    "  }\n" +
+    "}";
+
+  private static JsonPatchTransform jsonPatchTransform;
+  private static SourceRecord record;
+
+  @BeforeEach
+  public void initJsonPatchTransform() throws Exception {
+    final Map<String, String> configs = new HashMap<>();
+    configs.put("operations", jsonPatchString);
+
+    jsonPatchTransform = new JsonPatchTransform();
+    jsonPatchTransform.configure(configs);
+
+    record = new SourceRecord(new HashMap<>(), new HashMap<>(), "test-topic", 1, new ConnectSchema(STRING),
+                              "", new ConnectSchema(STRING), recordObjectString, 2L, headers);
+  }
+
+  @Test
+  public void testJsonPatch() throws JsonProcessingException {
+    final ConnectRecord transformedRecord = jsonPatchTransform.apply(record);
+    final JsonNode recordValueNode = SerializerDeserializerUtil.getMapper()
+      .readTree(transformedRecord.value().toString());
+    final JsonNode operations = recordValueNode.get("header").get("operations");
+    final JsonNode dataNode = operations.get("data");
+    final JsonNode identity = operations.get("identity");
+
+    assertNotNull(operations);
+    assertNotNull(dataNode);
+    assertNotNull(identity);
+
+    assertEquals("merge", dataNode.asText());
+    assertEquals("create", identity.asText());
+
+  }
+
+}


### PR DESCRIPTION
## Summary
Add json patch transformations to support adding complex json to message payload as part of kafka connect SMT.
Required to support upsert profile in AEP.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Changes
* Json patch SMT

## Relevant Documentation

_Please enter the links of any docs updated to reflect this change_

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
