### PR TITLE
Improved logging for the message published in AEP

### DIFF
--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorErrorReporterTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorErrorReporterTest.java
@@ -54,7 +54,7 @@ public class AEPSinkConnectorErrorReporterTest extends AbstractConnectorTest {
 
   @BeforeEach
   @Override
-  public void setup() throws IOException, HttpException {
+  public void setup() throws IOException {
     super.setup();
     inletFailedResponse();
   }

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorErrorReporterTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorErrorReporterTest.java
@@ -54,7 +54,7 @@ public class AEPSinkConnectorErrorReporterTest extends AbstractConnectorTest {
 
   @BeforeEach
   @Override
-  public void setup() throws JsonProcessingException {
+  public void setup() throws IOException, HttpException {
     super.setup();
     inletFailedResponse();
   }

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -54,7 +55,7 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
 
   @BeforeEach
   @Override
-  public void setup() throws JsonProcessingException {
+  public void setup() throws IOException, HttpException {
     super.setup();
     inletSuccessfulResponse();
     inletSuccessfulResponseViaProxy();

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AEPSinkConnectorTest.java
@@ -55,7 +55,7 @@ public class AEPSinkConnectorTest extends AbstractConnectorTest {
 
   @BeforeEach
   @Override
-  public void setup() throws IOException, HttpException {
+  public void setup() throws IOException {
     super.setup();
     inletSuccessfulResponse();
     inletSuccessfulResponseViaProxy();

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
@@ -13,7 +13,6 @@
 package com.adobe.platform.streaming.integration;
 
 import com.adobe.platform.streaming.JacksonFactory;
-import com.adobe.platform.streaming.http.HttpException;
 import com.adobe.platform.streaming.integration.extension.AEPConnectorTestWatcher;
 import com.adobe.platform.streaming.integration.extension.WiremockExtension;
 
@@ -80,7 +79,7 @@ public abstract class AbstractConnectorTest {
   public static final WiremockExtension wiremockExtensionViaProxy = new WiremockExtension(PORT_VIA_PROXY);
 
   @BeforeEach
-  public void setup() throws IOException, HttpException {
+  public void setup() throws IOException {
     connect = new EmbeddedConnectCluster.Builder()
         .name("aep-connect-cluster")
         .numWorkers(numberOfWorkers)

--- a/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
+++ b/streaming-connect-sink/src/test/java/com/adobe/platform/streaming/integration/AbstractConnectorTest.java
@@ -13,6 +13,7 @@
 package com.adobe.platform.streaming.integration;
 
 import com.adobe.platform.streaming.JacksonFactory;
+import com.adobe.platform.streaming.http.HttpException;
 import com.adobe.platform.streaming.integration.extension.AEPConnectorTestWatcher;
 import com.adobe.platform.streaming.integration.extension.WiremockExtension;
 
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -52,6 +54,9 @@ public abstract class AbstractConnectorTest {
   private static final String AUTH_TOKEN_RESPONSE_OAUTH2 = "{\"access_token\":\"accessToken\"," +
     "\"token_type\":\"bearer\",\"expires_in\":86400}";
 
+  private static final String AEP_CONNECTOR_INLET_SUCCESSFUL_RESPONSE =
+    "aep-connector-inlet-successful-response.json";
+
   protected static final int TOPIC_PARTITION = 1;
   protected static final int NUMBER_OF_TASKS = 1;
   protected static final String CONNECTOR_NAME = "aep-sink-connector";
@@ -75,7 +80,7 @@ public abstract class AbstractConnectorTest {
   public static final WiremockExtension wiremockExtensionViaProxy = new WiremockExtension(PORT_VIA_PROXY);
 
   @BeforeEach
-  public void setup() throws JsonProcessingException {
+  public void setup() throws IOException, HttpException {
     connect = new EmbeddedConnectCluster.Builder()
         .name("aep-connect-cluster")
         .numWorkers(numberOfWorkers)
@@ -119,12 +124,13 @@ public abstract class AbstractConnectorTest {
     connect.stop();
   }
 
-  public void inletSuccessfulResponse() throws JsonProcessingException {
+  public void inletSuccessfulResponse() throws IOException {
     wiremockExtension.getWireMockServer()
       .stubFor(WireMock
       .post(WireMock.urlEqualTo(getRelativeUrl()))
       .willReturn(ResponseDefinitionBuilder.responseDefinition()
-      .withJsonBody(JacksonFactory.OBJECT_MAPPER.readTree("{\"payloadReceived\": true}"))));
+      .withJsonBody(JacksonFactory.OBJECT_MAPPER.readTree(this.getClass().getClassLoader()
+      .getResourceAsStream(AEP_CONNECTOR_INLET_SUCCESSFUL_RESPONSE)))));
   }
 
   public void inletIMSAuthenticationSuccessfulResponse() throws JsonProcessingException {

--- a/streaming-connect-sink/src/test/resources/aep-connector-inlet-successful-response.json
+++ b/streaming-connect-sink/src/test/resources/aep-connector-inlet-successful-response.json
@@ -1,0 +1,22 @@
+{
+  "inletId": "9b0cb233972f3b0092992284c7353f5eead496218e8441a79b25e9421ea127f5",
+  "batchId": "1565638336649:1750:244",
+  "receivedTimeMs": 1565638336705,
+  "responses": [
+    {
+      "xactionId": "1565650704337:2124:92:3"
+    },
+    {
+      "status": 400,
+      "message": "inletId: [9b0cb233972f3b0092992284c7353f5eead496218e8441a79b25e9421ea127f5] imsOrgId: [{ORG_ID}] Message has unknown xdm format"
+    },
+    {
+      "status": 400,
+      "message": "inletId: [9b0cb233972f3b0092992284c7353f5eead496218e8441a79b25e9421ea127f5] imsOrgId: [{ORG_ID}] Message has an absent or wrong ims org in the header"
+    },
+    {
+      "status": 400,
+      "message": "inletId: [9b0cb233972f3b0092992284c7353f5eead496218e8441a79b25e9421ea127f5] imsOrgId: [{ORG_ID}] Message has unknown xdm format"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Add logging for number of message published and failed while sending data to AEP. Logs can be used by user to identify any error in the payload.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Changes
Log is added based on response from AEP endpoint, to handle each message response seperately.

## Relevant Documentation

_Please enter the links of any docs updated to reflect this change_

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
