### PR TITLE
Issue-78 CVE Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ native/*
 notifications/*
 wrapper/*
 full-stack/*
+.cursor/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
  # governing permissions and limitations under the License.
 ##
 
-FROM adoptopenjdk/openjdk11:jre-11.0.11_9-alpine
+FROM eclipse-temurin:11-jre-alpine
 
 ENV SCALA_VERSION="2.12" \
     KAFKA_VERSION="2.8.0"
@@ -23,9 +23,10 @@ ARG KAFKA_DIST_ASC=${KAFKA_DIST}.tgz.asc
 RUN set -x && \
     apk add --no-cache unzip curl ca-certificates gnupg jq && \
     eval $(gpg-agent --daemon) && \
-    curl -sSLO "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${KAFKA_DIST_TGZ}" && \
-    curl -sSLO https://dist.apache.org/repos/dist/release/kafka/${KAFKA_VERSION}/${KAFKA_DIST_ASC} && \
-    curl -sSL  https://kafka.apache.org/KEYS | gpg -q --import - && \
+    curl -fsSLO "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${KAFKA_DIST_TGZ}" && \
+    curl -fsSLO "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${KAFKA_DIST_ASC}" && \
+    curl -fsSL  https://downloads.apache.org/kafka/KEYS | gpg -q --import - && \
+    gpg --batch --verify "${KAFKA_DIST_ASC}" "${KAFKA_DIST_TGZ}" && \
     mkdir -p /opt && \
     mv ${KAFKA_DIST_TGZ} /tmp && \
     tar xfz /tmp/${KAFKA_DIST_TGZ} -C /opt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
  # governing permissions and limitations under the License.
 ##
 
-FROM eclipse-temurin:11-jre-alpine
+FROM eclipse-temurin:11.0.31_11-jre-alpine
 
 ENV SCALA_VERSION="2.12" \
     KAFKA_VERSION="2.8.0"

--- a/build.gradle
+++ b/build.gradle
@@ -296,10 +296,7 @@ configurations.all {
 allprojects {
   configurations.all {
     resolutionStrategy {
-      // Pin transitively-introduced libraries to CVE-remediated versions (see CVE.md).
-      // jackson-* (incl. annotations) is aligned via the jackson-bom platform.
       force 'commons-codec:commons-codec:1.18.0'
-      force 'org.yaml:snakeyaml:2.0'
       force 'org.apache.commons:commons-lang3:3.18.0'
       force 'com.fasterxml.jackson.core:jackson-core:2.21.3'
       force 'com.fasterxml.jackson.core:jackson-databind:2.21.3'

--- a/build.gradle
+++ b/build.gradle
@@ -292,14 +292,3 @@ task kafkaConnectPublish(type: Zip) {
 configurations.all {
   exclude module: 'slf4j-log4j12'
 }
-
-allprojects {
-  configurations.all {
-    resolutionStrategy {
-      force 'commons-codec:commons-codec:1.18.0'
-      force 'org.apache.commons:commons-lang3:3.18.0'
-      force 'com.fasterxml.jackson.core:jackson-core:2.21.3'
-      force 'com.fasterxml.jackson.core:jackson-databind:2.21.3'
-    }
-  }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -292,3 +292,17 @@ task kafkaConnectPublish(type: Zip) {
 configurations.all {
   exclude module: 'slf4j-log4j12'
 }
+
+allprojects {
+  configurations.all {
+    resolutionStrategy {
+      // Pin transitively-introduced libraries to CVE-remediated versions (see CVE.md).
+      // jackson-* (incl. annotations) is aligned via the jackson-bom platform.
+      force 'commons-codec:commons-codec:1.18.0'
+      force 'org.yaml:snakeyaml:2.0'
+      force 'org.apache.commons:commons-lang3:3.18.0'
+      force 'com.fasterxml.jackson.core:jackson-core:2.21.3'
+      force 'com.fasterxml.jackson.core:jackson-databind:2.21.3'
+    }
+  }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,6 +16,7 @@ ext {
 }
 
 versions.collections4 = '4.4'
+versions.commonscodec = '1.18.0'
 versions.commonslang = '3.18.0'
 versions.guava = '32.0.0-jre'
 versions.httpClient = '4.5.13'
@@ -32,6 +33,11 @@ versions.wiremock = '2.27.2'
 
 libraries.collections4 = [
   "org.apache.commons:commons-collections4:$versions.collections4"
+]
+
+
+libraries.commonscodec = [
+  "commons-codec:commons-codec:$versions.commonscodec"
 ]
 
 libraries.commonslang = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,10 +16,11 @@ ext {
 }
 
 versions.collections4 = '4.4'
-versions.commonslang = '3.9'
+versions.commonscodec = '1.18.0'
+versions.commonslang = '3.18.0'
 versions.guava = '32.0.0-jre'
 versions.httpClient = '4.5.13'
-versions.jackson = '2.14.0'
+versions.jackson = '2.21.3'
 versions.jmockit = '1.41'
 versions.jmxPrometheusJavaAgent = '0.12.0'
 versions.junitJupiter = '5.2.0'
@@ -29,9 +30,18 @@ versions.kafkaConnect = '2.8.1'
 versions.slf4j = '1.7.25'
 versions.jaxb = '2.3.0'
 versions.wiremock = '2.27.2'
+versions.snakeyaml = '2.0'
 
 libraries.collections4 = [
   "org.apache.commons:commons-collections4:$versions.collections4"
+]
+
+libraries.commonscodec = [
+  "commons-codec:commons-codec:$versions.commonscodec"
+]
+
+libraries.snakeyaml = [
+  "org.yaml:snakeyaml:$versions.snakeyaml"
 ]
 
 libraries.commonslang = [
@@ -46,10 +56,14 @@ libraries.httpClient = [
   "org.apache.httpcomponents:httpclient:$versions.httpClient"
 ]
 
+// jackson-bom keeps all Jackson modules aligned (jackson-annotations follows a
+// different patch cadence than core/databind, e.g. 2.21 vs 2.21.3).
+libraries.jacksonBom = "com.fasterxml.jackson:jackson-bom:$versions.jackson"
+
 libraries.jackson = [
-  "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
-  "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
-  "com.fasterxml.jackson.core:jackson-core:$versions.jackson"
+  "com.fasterxml.jackson.core:jackson-annotations",
+  "com.fasterxml.jackson.core:jackson-databind",
+  "com.fasterxml.jackson.core:jackson-core"
 ]
 
 libraries.jmockit = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,6 @@ ext {
 }
 
 versions.collections4 = '4.4'
-versions.commonscodec = '1.18.0'
 versions.commonslang = '3.18.0'
 versions.guava = '32.0.0-jre'
 versions.httpClient = '4.5.13'
@@ -30,18 +29,9 @@ versions.kafkaConnect = '2.8.1'
 versions.slf4j = '1.7.25'
 versions.jaxb = '2.3.0'
 versions.wiremock = '2.27.2'
-versions.snakeyaml = '2.0'
 
 libraries.collections4 = [
   "org.apache.commons:commons-collections4:$versions.collections4"
-]
-
-libraries.commonscodec = [
-  "commons-codec:commons-codec:$versions.commonscodec"
-]
-
-libraries.snakeyaml = [
-  "org.yaml:snakeyaml:$versions.snakeyaml"
 ]
 
 libraries.commonslang = [
@@ -56,8 +46,6 @@ libraries.httpClient = [
   "org.apache.httpcomponents:httpclient:$versions.httpClient"
 ]
 
-// jackson-bom keeps all Jackson modules aligned (jackson-annotations follows a
-// different patch cadence than core/databind, e.g. 2.21 vs 2.21.3).
 libraries.jacksonBom = "com.fasterxml.jackson:jackson-bom:$versions.jackson"
 
 libraries.jackson = [

--- a/streaming-connect-common/build.gradle
+++ b/streaming-connect-common/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation platform(libraries.jacksonBom)
     implementation libraries.collections4, libraries.commonslang, libraries.guava,
                    libraries.httpClient, libraries.jackson,
-                   libraries.jjwt, libraries.slf4j, libraries.jaxb,
-                   libraries.commonscodec, libraries.snakeyaml
+                   libraries.jjwt, libraries.slf4j, libraries.jaxb
     testImplementation libraries.jmockit, libraries.junitJupiter
 }

--- a/streaming-connect-common/build.gradle
+++ b/streaming-connect-common/build.gradle
@@ -13,8 +13,10 @@
 apply from: '../dependencies.gradle'
 
 dependencies {
+    implementation platform(libraries.jacksonBom)
     implementation libraries.collections4, libraries.commonslang, libraries.guava,
                    libraries.httpClient, libraries.jackson,
-                   libraries.jjwt, libraries.slf4j, libraries.jaxb
+                   libraries.jjwt, libraries.slf4j, libraries.jaxb,
+                   libraries.commonscodec, libraries.snakeyaml
     testImplementation libraries.jmockit, libraries.junitJupiter
 }

--- a/streaming-connect-common/build.gradle
+++ b/streaming-connect-common/build.gradle
@@ -14,8 +14,8 @@ apply from: '../dependencies.gradle'
 
 dependencies {
     implementation platform(libraries.jacksonBom)
-    implementation libraries.collections4, libraries.commonslang, libraries.guava,
-                   libraries.httpClient, libraries.jackson,
+    implementation libraries.collections4, libraries.commonscodec, libraries.commonslang,
+                   libraries.guava, libraries.httpClient, libraries.jackson,
                    libraries.jjwt, libraries.slf4j, libraries.jaxb
     testImplementation libraries.jmockit, libraries.junitJupiter
 }

--- a/streaming-connect-sink/build.gradle
+++ b/streaming-connect-sink/build.gradle
@@ -19,7 +19,7 @@ configurations {
 dependencies {
   implementation platform(libraries.jacksonBom)
   implementation project(':streaming-connect-common')
-  implementation libraries.collections4, libraries.commonslang,
+  implementation libraries.collections4, libraries.commonscodec, libraries.commonslang,
                  libraries.guava,
                  libraries.jackson, libraries.httpClient,
                  libraries.slf4j

--- a/streaming-connect-sink/build.gradle
+++ b/streaming-connect-sink/build.gradle
@@ -17,11 +17,13 @@ configurations {
 }
 
 dependencies {
+  implementation platform(libraries.jacksonBom)
   implementation project(':streaming-connect-common')
   implementation libraries.collections4, libraries.commonslang,
                  libraries.guava,
                  libraries.jackson, libraries.httpClient,
-                 libraries.slf4j
+                 libraries.slf4j,
+                 libraries.commonscodec, libraries.snakeyaml
   implementation libraries.jsonPatch
   compileOnly libraries.kafkaConnectRuntime, libraries.kafkaConnect
   jmxAgent libraries.jmxPrometheusJavaAgent

--- a/streaming-connect-sink/build.gradle
+++ b/streaming-connect-sink/build.gradle
@@ -22,8 +22,7 @@ dependencies {
   implementation libraries.collections4, libraries.commonslang,
                  libraries.guava,
                  libraries.jackson, libraries.httpClient,
-                 libraries.slf4j,
-                 libraries.commonscodec, libraries.snakeyaml
+                 libraries.slf4j
   implementation libraries.jsonPatch
   compileOnly libraries.kafkaConnectRuntime, libraries.kafkaConnect
   jmxAgent libraries.jmxPrometheusJavaAgent


### PR DESCRIPTION

Library | From → To | Findings Cleared
-- | -- | --
commons-codec | 1.11 → 1.18.0 | 1 (BDSA-2012-0001)
commons-lang3 | 3.9 → 3.18.0 | 1 (CVE-2025-48924)
jackson-core | 2.14.0 → 2.21.3 | 4 (CVE-2025-52999, BDSA-2022-4307, BDSA-2025-5555, GHSA-72hv-8253-57qq)
jackson-databind | 2.14.0 → 2.21.3 | Keep aligned with jackson-core via jackson-bom
jackson-databind (CVE-2023-35116) | N/A | Suppress — disputed, no fix exists

Issue #78 
